### PR TITLE
Allow use of several Vuex modules in same Vue component

### DIFF
--- a/src/factory/descriptor-factory.ts
+++ b/src/factory/descriptor-factory.ts
@@ -36,29 +36,30 @@ export class DescriptorFactory {
         }
         if (typeof a === 'string') {
             // a=fromKey, b=opts
-            return this.handleVuexDecorator(a);
+            return this.handleVuexDecorator(a, this.namespace);
         }
         if (typeof a === 'function') {
             // a=fromFn, b=opts
-            return this.handleVuexDecorator(a);
+            return this.handleVuexDecorator(a, this.namespace);
         }
         if (typeof b === 'string') {
             // b=toKey=fromKey
-            return this.handleVuexDecorator(b)(a, b);
+            return this.handleVuexDecorator(b, this.namespace)(a, b);
         }
     }
 
     /**
      * 处理vuex装饰器
      * @param fromKey
+     * @param fromNs
      * @private
      */
-    private handleVuexDecorator(fromKey?: any) {
+    private handleVuexDecorator(fromKey?: any, fromNs?: any) {
         return createDecorator((options, toKey) => {
             options[this.bindProperty] ??= {};
             const params = {[toKey]: fromKey ?? toKey};
-            const mapHelper = this.namespace
-                ? this.vuexMapHelper(this.namespace, params)
+            const mapHelper = fromNs
+                ? this.vuexMapHelper(fromNs, params)
                 : this.vuexMapHelper(params);
             const helper = mapHelper[toKey];
             switch (this.bindProperty) {

--- a/tests/multiple-vuex-modules.spec.ts
+++ b/tests/multiple-vuex-modules.spec.ts
@@ -1,0 +1,35 @@
+import 'mocha';
+import { expect } from 'chai';
+import { Component, Vue } from 'vue-facing-decorator';
+import { shallowMount } from '@vue/test-utils';
+import { useStore } from './vuex';
+import { State } from '../src';
+import { h } from 'vue';
+
+@Component
+class Tests extends Vue {
+    @State('someName', { namespace: 'useModuleA' }) // Module A
+    readonly someNameA!: string;
+
+    @State('someNameB', { namespace: 'useModuleB' }) // Module B
+    readonly someNameB!: string;
+
+    render() {
+        return h('div');
+    }
+}
+
+describe('test with 2 different namespaced modules', () => {
+    const wrapper = shallowMount(Tests, {
+        global: {
+            plugins: [useStore]
+        }
+    });
+    const vm = wrapper.vm as any;
+    it('State:useModuleA:someName', function () {
+        expect(vm.someNameA).to.equal('someName vuex');
+    });
+    it('State:useModuleB:someNameB', function () {
+        expect(vm.someNameB).to.equal('someName vuex B');
+    });
+});

--- a/tests/vuex/index.ts
+++ b/tests/vuex/index.ts
@@ -1,8 +1,8 @@
 import { createStore } from 'vuex';
-import { useModuleA } from './modules';
+import { useModuleA, useModuleB } from './modules';
 
 export const useStore = createStore({
-    modules: {useModuleA},
+    modules: {useModuleA, useModuleB},
     state: {
         globalCount: 100,
         globalSomeName: 'globalSomeName vuex',

--- a/tests/vuex/modules/index.ts
+++ b/tests/vuex/modules/index.ts
@@ -1,1 +1,2 @@
 export * from './use-module-a';
+export * from './use-module-b';

--- a/tests/vuex/modules/use-module-b.ts
+++ b/tests/vuex/modules/use-module-b.ts
@@ -1,0 +1,6 @@
+export const useModuleB = {
+    namespaced: true,
+    state: () => ({
+        someNameB: 'someName vuex B'
+    })
+};


### PR DESCRIPTION
Hi !

First, thank you @wangzhiguoengineer  for the great work, it allowed us to migrate to Vue 3 ♥

We just had a problem when we use 2 different VueX modules in the same Vue component, using `{ namespace: '...' }` .

For exemple :

![ns](https://github.com/wangzhiguoengineer/vuex-facing-decorator/assets/2787377/53d63d71-b7f3-4ef7-a750-1c7f71ffdcd7)

Debugging the code I noticed the namespace is overridden, and the last one of the Component wins.

The problem can be reproduced via unit test (see tests/multiple-vuex-modules.spec.ts).

I tried to fix it, but I'm not sure it's the good way of doing it, sorry if so.

Regards from France,
Renaud
